### PR TITLE
ログインの入力チェック不具合を解消

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -94,18 +94,21 @@ func Delete(c *gin.Context) {
 
 // Login action: POST /Auth
 func Login(c *gin.Context) {
-	var inputUser entity.User
+	inputUser := struct {
+		Email    string
+		Password string
+	}{}
 	if err := bindJSON(c, &inputUser); err != nil {
 		return
 	}
 
 	var b service.Behavior
-	auth, err := b.LoginAuth(inputUser)
+	auth, err := b.LoginAuth(inputUser.Email, inputUser.Password)
 	if err != nil {
 		c.AbortWithStatus(403)
 		fmt.Println(err)
 	} else {
-		c.JSON(200, auth)
+		c.JSON(http.StatusCreated, auth)
 	}
 }
 
@@ -118,7 +121,7 @@ func Auth(c *gin.Context) {
 		c.AbortWithStatus(http.StatusBadRequest)
 		fmt.Println(err)
 	} else {
-		c.JSON(201, user)
+		c.JSON(http.StatusOK, user)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -106,6 +106,25 @@ func TestUserCreateEmailUniqueErrValid(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestLoginSuccess(t *testing.T) {
+	initUserTable()
+	input, _ := json.Marshal(userDefault)
+	resp, _ := http.Post(testServer.URL+"/users", "application/json", bytes.NewBuffer(input))
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	loginUser := struct {
+		Email    string
+		Password string
+	}{
+		userDefault.Email,
+		userDefault.Password,
+	}
+
+	input, _ = json.Marshal(loginUser)
+	resp, _ = http.Post(testServer.URL+"/auth", "application/json", bytes.NewBuffer(input))
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
 func initUserTable() {
 	db := db.GetDB()
 	var u entity.User

--- a/service/service.go
+++ b/service/service.go
@@ -103,14 +103,14 @@ func (b Behavior) DeleteByID(id string) error {
 }
 
 // LoginAuth ログイン認証を行い認証トークンを発行
-func (b Behavior) LoginAuth(inputUser entity.User) (entity.Auth, error) {
-	dbUser, err := b.GetUserByEmail(inputUser.Email)
+func (b Behavior) LoginAuth(email string, password string) (entity.Auth, error) {
+	dbUser, err := b.GetUserByEmail(email)
 	if err != nil {
 		return entity.Auth{}, err
 	}
 
 	// パスワードの確認
-	err = bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(inputUser.Password))
+	err = bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password))
 	if err != nil {
 		return entity.Auth{}, err
 	}


### PR DESCRIPTION
ログイン時に登録と同じ入力チェックを行っていたため分離して入力チェックを行うように対応
#9